### PR TITLE
Fix Sveltekit build command

### DIFF
--- a/examples/sveltekit/README.md
+++ b/examples/sveltekit/README.md
@@ -36,5 +36,5 @@ pnpm build:sveltekit
 7. Run the following command from the repository root
 
 ```bash
-pnpm dev --filter=@example/sveltekit-email-password -- --open
+pnpm dev --filter=@example/sveltekit -- --open
 ```


### PR DESCRIPTION
Quick fix for the build command in the README.
 
<details>
<summary>Before</summary>

![image](https://github.com/mdjohns/auth-helpers/assets/13648640/da308f0b-21ad-4161-b8a9-696427a423bc)

</details>

<details>
<summary>After</summary>

![image](https://github.com/mdjohns/auth-helpers/assets/13648640/17bf09e3-3e79-434b-a5bb-251abba4726c)

</details>